### PR TITLE
Fix code scanning alert no. 14: Uncontrolled data used in path expression

### DIFF
--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -4,6 +4,7 @@ import hashlib
 import smtplib
 import json
 from flask import request, jsonify, send_file
+from werkzeug.utils import secure_filename
 from . import app, db
 from .models import FileUpload
 
@@ -142,7 +143,10 @@ def upload_file():
         if not os.path.exists(upload_dir):
             os.makedirs(upload_dir)
 
-        upload_path = os.path.join(upload_dir, file.filename)
+        sanitized_filename = secure_filename(file.filename)
+        upload_path = os.path.normpath(os.path.join(upload_dir, sanitized_filename))
+        if not upload_path.startswith(upload_dir):
+            raise Exception("Invalid file path")
         with open(upload_path, 'wb') as f:
             f.write(file_content)
 


### PR DESCRIPTION
Fixes [https://github.com/tiritibambix/iTransfer/security/code-scanning/14](https://github.com/tiritibambix/iTransfer/security/code-scanning/14)

To fix the problem, we need to ensure that the filename provided by the user is sanitized and validated before it is used to construct the file path. We can use the `werkzeug.utils.secure_filename` function to sanitize the filename, which will remove any special characters and ensure that the filename is safe to use. Additionally, we should normalize the path and ensure it is within the intended upload directory.

1. Import the `secure_filename` function from `werkzeug.utils`.
2. Use `secure_filename` to sanitize the `file.filename`.
3. Normalize the constructed file path using `os.path.normpath`.
4. Ensure the normalized path starts with the intended upload directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
