### PR TITLE
Fix code scanning alert no. 13: Uncontrolled data used in path expression

### DIFF
--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -4,6 +4,7 @@ import hashlib
 import smtplib
 import json
 from flask import request, jsonify, send_file
+from werkzeug.utils import secure_filename
 from . import app, db
 from .models import FileUpload
 
@@ -142,7 +143,8 @@ def upload_file():
         if not os.path.exists(upload_dir):
             os.makedirs(upload_dir)
 
-        upload_path = os.path.join(upload_dir, file.filename)
+        safe_filename = secure_filename(file.filename)
+        upload_path = os.path.join(upload_dir, safe_filename)
         with open(upload_path, 'wb') as f:
             f.write(file_content)
 


### PR DESCRIPTION
Fixes [https://github.com/tiritibambix/iTransfer/security/code-scanning/13](https://github.com/tiritibambix/iTransfer/security/code-scanning/13)

To fix the problem, we need to validate and sanitize the `file.filename` before using it to construct the `upload_path`. The best way to do this is to use the `werkzeug.utils.secure_filename` function, which ensures that the filename is safe and does not contain any special characters or path traversal sequences.

1. Import the `secure_filename` function from `werkzeug.utils`.
2. Use `secure_filename` to sanitize `file.filename` before using it to construct the `upload_path`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
