### PR TITLE
Fix code scanning alert no. 11: Uncontrolled data used in path expression

### DIFF
--- a/backend/app/app.py
+++ b/backend/app/app.py
@@ -4,6 +4,7 @@ from . import app, db
 from .config import Config
 from .database import init_db
 import os
+from werkzeug.utils import secure_filename
 
 def create_app():
     app = Flask(__name__)
@@ -53,7 +54,8 @@ def upload_file():
         if not os.path.exists(upload_dir):
             os.makedirs(upload_dir)
 
-        upload_path = os.path.join(upload_dir, file.filename)
+        safe_filename = secure_filename(file.filename)
+        upload_path = os.path.join(upload_dir, safe_filename)
         file.save(upload_path)
 
         return jsonify({"message": f"Fichier {file.filename} reçu avec succès"}), 201


### PR DESCRIPTION
Fixes [https://github.com/tiritibambix/iTransfer/security/code-scanning/11](https://github.com/tiritibambix/iTransfer/security/code-scanning/11)

To fix the problem, we need to ensure that the filename provided by the user does not contain any directory traversal sequences and is a safe filename. We can use the `werkzeug.utils.secure_filename` function to sanitize the filename. This function removes any special characters and ensures that the filename is safe to use.

1. Import the `secure_filename` function from `werkzeug.utils`.
2. Use `secure_filename` to sanitize the user-provided filename before constructing the file path.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
