### PR TITLE
Fix code scanning alert no. 10: Information exposure through an exception

### DIFF
--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -297,7 +297,7 @@ def download_file(file_id):
 
     except Exception as e:
         app.logger.error(f"Erreur lors du téléchargement : {str(e)}")
-        return jsonify({'error': str(e)}), 500
+        return jsonify({'error': 'An internal error has occurred!'}), 500
 
 @app.route('/api/test-smtp', methods=['POST', 'OPTIONS'])
 def test_smtp():
@@ -344,6 +344,6 @@ Si vous recevez cet email, la configuration est correcte."""
 
     except Exception as e:
         app.logger.error(f"Erreur lors du test SMTP : {str(e)}")
-        response = jsonify({"success": False, "error": str(e)})
+        response = jsonify({"success": False, "error": "An internal error has occurred!"})
         response.headers.add("Access-Control-Allow-Origin", '*')
         return response, 500


### PR DESCRIPTION
Fixes [https://github.com/tiritibambix/iTransfer/security/code-scanning/10](https://github.com/tiritibambix/iTransfer/security/code-scanning/10)

To fix the problem, we need to ensure that detailed error messages are not exposed to the end user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by modifying the exception handling code to return a generic error message while logging the detailed error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
