### PR TITLE
Fix code scanning alert no. 8: Information exposure through an exception

### DIFF
--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -228,7 +228,7 @@ def save_smtp_settings():
         return response, 200
     except Exception as e:
         app.logger.error(f"Erreur lors de la sauvegarde des paramètres SMTP : {e}")
-        response = jsonify({"error": str(e)})
+        response = jsonify({"error": "Une erreur interne est survenue."})
         response.headers.add("Access-Control-Allow-Origin", '*')
         response.headers.add("Access-Control-Allow-Methods", "POST, OPTIONS")
         response.headers.add("Access-Control-Allow-Headers", "Content-Type")


### PR DESCRIPTION
Fixes [https://github.com/tiritibambix/iTransfer/security/code-scanning/8](https://github.com/tiritibambix/iTransfer/security/code-scanning/8)

To fix the problem, we need to ensure that detailed exception messages are not exposed to the client. Instead, we should log the detailed error message on the server and return a generic error message to the client. This can be achieved by modifying the exception handling block to log the error and return a generic message.

- Modify the exception handling block in the `save_smtp_settings` function to log the detailed error message using `app.logger.error` and return a generic error message to the client.
- Ensure that the response headers for CORS are still included in the response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
