### PR TITLE
Fix code scanning alert no. 7: Information exposure through an exception

### DIFF
--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -190,7 +190,7 @@ def upload_file():
         app.logger.error(f"Erreur lors de l'upload : {str(e)}")
         if 'upload_path' in locals() and os.path.exists(upload_path):
             os.remove(upload_path)
-        return jsonify({'error': str(e)}), 500
+        return jsonify({'error': 'An internal error has occurred.'}), 500
 
 @app.route('/api/save-smtp-settings', methods=['POST', 'OPTIONS'])
 def save_smtp_settings():
@@ -228,7 +228,7 @@ def save_smtp_settings():
         return response, 200
     except Exception as e:
         app.logger.error(f"Erreur lors de la sauvegarde des paramètres SMTP : {e}")
-        response = jsonify({"error": str(e)})
+        response = jsonify({"error": "An internal error has occurred."})
         response.headers.add("Access-Control-Allow-Origin", '*')
         response.headers.add("Access-Control-Allow-Methods", "POST, OPTIONS")
         response.headers.add("Access-Control-Allow-Headers", "Content-Type")


### PR DESCRIPTION
Fixes [https://github.com/tiritibambix/iTransfer/security/code-scanning/7](https://github.com/tiritibambix/iTransfer/security/code-scanning/7)

To fix the problem, we need to ensure that detailed error messages are not exposed to the client. Instead, we should log the detailed error message on the server and return a generic error message to the client. This can be achieved by modifying the exception handling code to return a generic error message while logging the actual exception details.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
