### PR TITLE
Fix code scanning alert no. 6: Information exposure through an exception

### DIFF
--- a/backend/app/app.py
+++ b/backend/app/app.py
@@ -60,7 +60,7 @@ def upload_file():
 
     except Exception as e:
         app.logger.error(f"Erreur lors de l'upload : {e}")
-        return jsonify({"error": str(e)}), 400
+        return jsonify({"error": "An internal error has occurred."}), 400
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=5000)


### PR DESCRIPTION
Fixes [https://github.com/tiritibambix/iTransfer/security/code-scanning/6](https://github.com/tiritibambix/iTransfer/security/code-scanning/6)

To fix the problem, we need to ensure that detailed error information is not exposed to the end user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by modifying the exception handling block to return a generic error message while keeping the logging of the detailed error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
