### PR TITLE
Potential fix for code scanning alert no. 25: Clear-text logging of sensitive information

### DIFF
--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -678,7 +678,7 @@ def save_smtp_settings():
             'smtp_sender_email': data['smtpSenderEmail']
         }
 
-        app.logger.info(f"Configuration SMTP : serveur={smtp_config['smtp_server']}, port={smtp_config['smtp_port']}, user={smtp_config['smtp_user']}, sender={smtp_config['smtp_sender_email']} (password not logged)")
+        app.logger.info("Configuration SMTP reçue et sauvegardée (détails non inclus pour des raisons de sécurité)")
         
         # Sauvegarder la configuration
         with open(app.config['SMTP_CONFIG_PATH'], 'w') as config_file:

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -678,7 +678,7 @@ def save_smtp_settings():
             'smtp_sender_email': data['smtpSenderEmail']
         }
 
-        app.logger.info(f"Configuration SMTP : serveur={smtp_config['smtp_server']}, port={smtp_config['smtp_port']}, user={smtp_config['smtp_user']}, sender={smtp_config['smtp_sender_email']}")
+        app.logger.info(f"Configuration SMTP : serveur={smtp_config['smtp_server']}, port={smtp_config['smtp_port']}, user={smtp_config['smtp_user']}, sender={smtp_config['smtp_sender_email']} (password not logged)")
         
         # Sauvegarder la configuration
         with open(app.config['SMTP_CONFIG_PATH'], 'w') as config_file:


### PR DESCRIPTION
Potential fix for [https://github.com/tiritibambix/iTransfer/security/code-scanning/25](https://github.com/tiritibambix/iTransfer/security/code-scanning/25)

To fix the problem, we need to ensure that sensitive information, such as the SMTP password, is not logged in clear text. The best way to fix this issue without changing existing functionality is to modify the logging statement to exclude the sensitive data. Specifically, we should remove the SMTP password from the log message.

We will edit the logging statement on line 681 to exclude the `smtp_password` field from the logged message. This change will ensure that sensitive information is not exposed in the logs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
