### PR TITLE
Potential fix for code scanning alert no. 24: Information exposure through an exception

### DIFF
--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -745,4 +745,4 @@ def test_smtp():
 
     except Exception as e:
         app.logger.error(f"Erreur inattendue lors du test SMTP : {str(e)}")
-        return jsonify({'error': f'Erreur lors du test SMTP : {str(e)}'}), 500
+        return jsonify({'error': 'Une erreur interne est survenue lors du test SMTP.'}), 500


### PR DESCRIPTION
Potential fix for [https://github.com/tiritibambix/iTransfer/security/code-scanning/24](https://github.com/tiritibambix/iTransfer/security/code-scanning/24)

To fix the problem, we need to ensure that detailed error messages are not exposed to the end user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by modifying the return statement on line 748 to return a generic error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
