### PR TITLE
Potential fix for code scanning alert no. 23: Information exposure through an exception

### DIFF
--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -733,7 +733,7 @@ def test_smtp():
 
         except Exception as e:
             app.logger.error(f"Erreur lors de la création du message de test : {str(e)}")
-            return jsonify({'error': f'Erreur lors de la création du message : {str(e)}'}), 500
+            return jsonify({'error': 'Erreur lors de la création du message.'}), 500
 
         # Tenter d'envoyer l'email
         if send_email_with_smtp(msg, smtp_config):


### PR DESCRIPTION
Potential fix for [https://github.com/tiritibambix/iTransfer/security/code-scanning/23](https://github.com/tiritibambix/iTransfer/security/code-scanning/23)

To fix the problem, we need to ensure that detailed error messages are not exposed to end users. Instead, we should log the detailed error messages on the server and return a generic error message to the user. This can be achieved by modifying the code to log the exception details and return a generic error message.

1. Modify the code on line 736 to log the detailed error message and return a generic error message.
2. Ensure that the logging mechanism is already in place to capture the detailed error messages.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
