### PR TITLE
Potential fix for code scanning alert no. 22: Information exposure through an exception

### DIFF
--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -689,7 +689,7 @@ def save_smtp_settings():
 
     except Exception as e:
         app.logger.error(f"Erreur lors de la sauvegarde de la configuration SMTP : {str(e)}")
-        return jsonify({'error': f'Erreur lors de la sauvegarde : {str(e)}'}), 500
+        return jsonify({'error': 'Une erreur interne est survenue lors de la sauvegarde.'}), 500
 
 @app.route('/api/test-smtp', methods=['POST'])
 def test_smtp():


### PR DESCRIPTION
Potential fix for [https://github.com/tiritibambix/iTransfer/security/code-scanning/22](https://github.com/tiritibambix/iTransfer/security/code-scanning/22)

To fix the problem, we need to ensure that detailed error messages are logged on the server side, while a generic error message is returned to the client. This can be achieved by modifying the exception handling code to log the detailed error message and return a generic message in the response.

- Modify the exception handling block in the `save_smtp_settings` function to log the detailed error message using `app.logger.error` and return a generic error message in the JSON response.
- Ensure that the stack trace or any sensitive information is not included in the response sent to the client.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
